### PR TITLE
Fix iOS text entry issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/ui",
-  "version": "4.0.5",
+  "version": "4.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/ui",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Styles and React components for the Network Canvas project",
   "main": "lib/components/index.js",
   "license": "GPL-3.0-or-later",

--- a/src/styles/components/_inputs.scss
+++ b/src/styles/components/_inputs.scss
@@ -168,7 +168,6 @@
         transform: scale(1) translate(0, 0);
         transform-origin: left top 0;
         pointer-events: none;
-        user-select: none;
         z-index: 1;
       }
 

--- a/src/styles/global/core/_normalize.scss
+++ b/src/styles/global/core/_normalize.scss
@@ -30,7 +30,9 @@
 
 
   // Prevent text selection except when an element has a given class.
-  * {
+  // IMPORTANT: input and textarea are excepted because including them
+  // locks the input on iOS!
+  *:not(input):not(textarea) {
     user-select: none;
 
     .allow-text-selection,


### PR DESCRIPTION
We have been plagued by an issue where users could not enter more than a single character of text on iOS devices. We initially believed this was due to Babel dependency breakages, but I have now isolated the fundamental cause, which was that we applied `user-select: none` to all elements, including `<input />` and `<textarea />`.

This was not immediately apparent as the cause, because the property requires prefixing on iOS, and older dependency versions erroneously failed to do this.

This release fixes the issue in a somewhat kludgy way by exempting these elements using chained `:not` statements.