### PR TITLE
implement clickable styles and other small features on boolean input

### DIFF
--- a/src/components/Boolean/Boolean.js
+++ b/src/components/Boolean/Boolean.js
@@ -3,14 +3,16 @@ import PropTypes from 'prop-types';
 import BooleanOption from './BooleanOption';
 
 const Boolean = ({
+  noReset,
   options,
   value,
   onChange,
 }) => (
   <div className="form-field boolean">
     <div className="boolean__options">
-      {options.map(({ label, value: optionValue }) => (
+      {options.map(({ label, value: optionValue, classes }) => (
         <BooleanOption
+          classes={classes}
           key={optionValue}
           label={label}
           selected={value === optionValue}
@@ -18,11 +20,13 @@ const Boolean = ({
         />
       ))}
     </div>
+    { !noReset && (
     <div className="boolean__reset">
       <div onClick={() => onChange(null)}>
         Reset answer
       </div>
     </div>
+    )}
   </div>
 );
 
@@ -33,11 +37,16 @@ const valuePropTypes = PropTypes.oneOfType([
 ]);
 
 const optionPropTypes = PropTypes.shape({
-  label: PropTypes.string,
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func,
+  ]).isRequired,
   value: valuePropTypes,
+  classes: PropTypes.string,
 });
 
 Boolean.propTypes = {
+  noReset: PropTypes.bool.isRequired,
   options: PropTypes.arrayOf(optionPropTypes),
   value: valuePropTypes,
   onChange: PropTypes.func,

--- a/src/components/Boolean/BooleanOption.js
+++ b/src/components/Boolean/BooleanOption.js
@@ -5,30 +5,45 @@ import RoundCheckbox from './RoundCheckbox';
 import MarkdownLabel from '../Fields/MarkdownLabel';
 
 const BooleanOption = ({
+  classes,
   selected,
   label,
   onClick,
 }) => {
-  const classes = cx(
+  const classNames = cx(
     'boolean-option',
     { 'boolean-option--selected': selected },
+    classes,
   );
 
+  const renderLabel = () => {
+    if (typeof label === 'function') {
+      return label();
+    }
+
+    return <MarkdownLabel label={label} className="form-field-inline-label" />;
+  };
+
   return (
-    <div className={classes} onClick={onClick}>
+    <div className={classNames} onClick={onClick}>
       <RoundCheckbox checked={selected} />
-      <MarkdownLabel label={label} className="form-field-inline-label" />
+      {renderLabel()}
     </div>
   );
 };
 
 BooleanOption.propTypes = {
+  classes: PropTypes.string,
   selected: PropTypes.bool,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func,
+  ]).isRequired,
   onClick: PropTypes.func,
 };
 
 BooleanOption.defaultProps = {
+  classes: null,
   selected: false,
   onClick: () => {},
 };

--- a/src/components/Fields/Boolean.js
+++ b/src/components/Fields/Boolean.js
@@ -6,6 +6,7 @@ import Boolean from '../Boolean/Boolean';
 
 const BooleanField = ({
   label,
+  noReset,
   className,
   input,
   disabled,
@@ -27,27 +28,40 @@ const BooleanField = ({
           options={options}
           value={input.value}
           onChange={input.onChange}
+          noReset={noReset}
         />
       </div>
     </div>
   );
 };
 
+const valuePropTypes = PropTypes.oneOfType([
+  PropTypes.bool,
+  PropTypes.string,
+  PropTypes.number,
+]);
+
 BooleanField.propTypes = {
   label: PropTypes.node,
+  noReset: PropTypes.bool,
   className: PropTypes.string,
   disabled: PropTypes.bool,
   input: PropTypes.object.isRequired,
   options: PropTypes.arrayOf(
     PropTypes.shape({
-      label: PropTypes.string.isRequired,
-      value: PropTypes.bool.isRequired,
+      label: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.func,
+      ]).isRequired,
+      value: valuePropTypes,
+      classes: PropTypes.string,
     }),
   ),
 };
 
 BooleanField.defaultProps = {
   className: '',
+  noReset: false,
   label: null,
   disabled: false,
   options: [

--- a/src/styles/components/form/_fields.scss
+++ b/src/styles/components/form/_fields.scss
@@ -20,8 +20,6 @@ $global-input-border-space: 0.25rem;
 }
 
 .form-field-inline-label {
-  margin-left: unit(1);
-
   > :first-child {
     margin-top: 0;
   }

--- a/src/styles/components/form/fields/_boolean.scss
+++ b/src/styles/components/form/fields/_boolean.scss
@@ -9,6 +9,7 @@
   }
 
   &__reset {
+    cursor: pointer;
     display: block;
     font-size: .9rem;
     margin-top: 1rem;
@@ -18,7 +19,9 @@
 }
 
 .boolean-option {
-  flex: 0 0 calc(50% - #{unit(0.5)});
+  @include clickable(1);
+  cursor: pointer;
+  flex: 1 1;
   display: inline-flex;
   border-color: transparent;
   border-width: $global-input-border-size;
@@ -30,13 +33,13 @@
   margin-left: 0;
   background: var(--input-background);
   color: var(--input-label);
-  transition-property: border-color;
-  transition-duration: var(--animation-duration-standard);
-  transition-timing-function: var(--animation-easing);
 
   &:last-child {
     margin-right: 0;
-    margin-left: unit(0.5);
+  }
+
+  &:hover {
+    // border-color: var(--input-accent);
   }
 
   &--selected {
@@ -59,6 +62,7 @@
   transition-property: border-color, background-color;
   transition-duration: var(--animation-duration-standard);
   transition-timing-function: var(--animation-easing);
+  margin-right: unit(1);
 
   svg {
     width: $global-input-element-size * 0.5;

--- a/src/styles/components/form/fields/_checkbox.scss
+++ b/src/styles/components/form/fields/_checkbox.scss
@@ -20,6 +20,7 @@
     width: $global-input-element-size;
     height: $global-input-element-size;
     display: inline-flex;
+    margin-right: unit(1);
 
     &::before {
       position: absolute;

--- a/src/styles/components/form/fields/_radio.scss
+++ b/src/styles/components/form/fields/_radio.scss
@@ -19,6 +19,7 @@
     width: $global-input-element-size;
     height: $global-input-element-size;
     display: inline-block;
+    margin-right: unit(1);
 
     &::before {
       position: absolute;

--- a/src/styles/components/form/fields/_toggle-button.scss
+++ b/src/styles/components/form/fields/_toggle-button.scss
@@ -13,6 +13,8 @@ $component-name: form-field-togglebutton;
   }
 
   &__checkbox {
+    @include clickable;
+    border-radius: 50%;
     position: relative;
     width: $size;
     height: $size;

--- a/src/styles/components/form/fields/_toggle.scss
+++ b/src/styles/components/form/fields/_toggle.scss
@@ -15,6 +15,7 @@ $component-name: form-field-toggle;
     width: $global-input-element-size * 2;
     height: $global-input-element-size;
     display: inline-block;
+    margin-right: unit(1);
   }
 
   &__button {

--- a/stories/Boolean.stories.js
+++ b/stories/Boolean.stories.js
@@ -4,6 +4,8 @@ import Harness from './helpers/Harness';
 import Boolean from '../src/components/Fields/Boolean';
 import '../src/styles/_all.scss';
 
+import './Boolean.stories.scss';
+
 export default { title: 'Fields/Boolean' };
 
 const requiredProps = {
@@ -29,7 +31,71 @@ export const interaction = () => {
         value,
       }}
     >
-      {(props) => <Boolean {...props} />}
+      {(props) => (
+        <>
+          <Boolean {...props} />
+          next element
+        </>
+      )}
+    </Harness>
+  );
+};
+
+export const jsxLabels = () => {
+  const [value, setValue] = useState();
+
+  const handleChange = (...args) => {
+    setValue(...args);
+    action('change')(...args);
+  };
+
+  return (
+    <Harness
+      requiredProps={requiredProps}
+      label="This input type **requires** the user to _specifically_ set a value, which can also be cleared."
+      input={{
+        onChange: handleChange,
+        value,
+      }}
+      options={[
+        { label: () => <h1>Yes</h1>, value: true },
+        { label: () => <h1>No</h1>, value: false },
+      ]}
+    >
+      {(props) => (
+        <>
+          <Boolean {...props} />
+          next element
+        </>
+      )}
+    </Harness>
+  );
+};
+
+export const withoutReset = () => {
+  const [value, setValue] = useState();
+
+  const handleChange = (...args) => {
+    setValue(...args);
+    action('change')(...args);
+  };
+
+  return (
+    <Harness
+      requiredProps={requiredProps}
+      label="This input type **requires** the user to _specifically_ set a value, which can also be cleared."
+      input={{
+        onChange: handleChange,
+        value,
+      }}
+      noReset
+    >
+      {(props) => (
+        <>
+          <Boolean {...props} />
+          next element
+        </>
+      )}
     </Harness>
   );
 };
@@ -55,7 +121,12 @@ export const longText = () => {
         { label: 'No', value: false },
       ]}
     >
-      {(props) => <Boolean {...props} />}
+      {(props) => (
+        <>
+          <Boolean {...props} />
+          next element
+        </>
+      )}
     </Harness>
   );
 };
@@ -77,11 +148,50 @@ export const longTextWithList = () => {
         value,
       }}
       options={[
-        { label: '**Yes**. This is a really long label that represents the value yes.\n\n- Are there any other questions?\n\n- Are there any other questions?\n\n- Are there any other questions?', value: true },
-        { label: '**No**. This is a really long label that represents the value no.\n\n- Are there any other questions?\n\n- Are there any other questions?\n\n- Are there any other questions?', value: false },
+        { label: '# Yes\n\nThis is a really long label that represents the value yes.\n\n- Are there any other questions?\n\n- Are there any other questions?\n\n- Are there any other questions?', value: true },
+        { label: '# No\n\nThis is a really long label that represents the value no.\n\n- Are there any other questions?\n\n- Are there any other questions?\n\n- Are there any other questions?', value: false },
       ]}
     >
-      {(props) => <Boolean {...props} />}
+      {(props) => (
+        <>
+          <Boolean {...props} />
+          next element
+        </>
+      )}
+    </Harness>
+  );
+};
+
+export const withFiveItems = () => {
+  const [value, setValue] = useState();
+
+  const handleChange = (...args) => {
+    setValue(...args);
+    action('change')(...args);
+  };
+
+  return (
+    <Harness
+      requiredProps={requiredProps}
+      label="This version has longer labels that include list items."
+      input={{
+        onChange: handleChange,
+        value,
+      }}
+      options={[
+        { label: 'All the time', value: 5 },
+        { label: 'Most of the time', value: 4 },
+        { label: 'Sometimes', value: 3 },
+        { label: 'Rarely', value: 2 },
+        { label: 'Never', value: 1, classes: 'red' },
+      ]}
+    >
+      {(props) => (
+        <>
+          <Boolean {...props} />
+          next element
+        </>
+      )}
     </Harness>
   );
 };

--- a/stories/Boolean.stories.scss
+++ b/stories/Boolean.stories.scss
@@ -1,0 +1,3 @@
+.red {
+  background: red;
+}

--- a/stories/BooleanOption.stories.js
+++ b/stories/BooleanOption.stories.js
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import { action } from '@storybook/addon-actions';
+import Harness from './helpers/Harness';
+import BooleanOption from '../src/components/Boolean/BooleanOption';
+import '../src/styles/_all.scss';
+
+import './Boolean.stories.scss';
+
+export default { title: 'Fields/BooleanOption' };
+
+const requiredProps = {
+  label: 'This is the **boolean** option.',
+  value: true,
+};
+
+export const renders = () => {
+  return (
+    <Harness
+      requiredProps={requiredProps}
+    >
+      {(props) => <BooleanOption {...props} />}
+    </Harness>
+  );
+};
+
+export const customClass = () => {
+  return (
+    <Harness
+      requiredProps={requiredProps}
+      classes="red"
+    >
+      {(props) => <BooleanOption {...props} />}
+    </Harness>
+  );
+};


### PR DESCRIPTION
This PR changes some details of the new boolean input:

- Allows for option labels to be JSX so that specific content can be rendered when used on the dyad census
- Allows for <BooleanOption /> to have a custom class, as used on the tie strength census interface
- Adds a the clickable mixin for clickable affordances
- Adds the ability to have up to 5 options (and numerical option values), as used by the tie strength census. 