### PR TITLE
don't render button content if only icon is provided

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/ui",
-  "version": "5.7.4",
+  "version": "5.7.5",
   "description": "Styles and React components for the Network Canvas project",
   "main": "lib/components/index.js",
   "license": "GPL-3.0-or-later",

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -58,9 +58,7 @@ class Button extends PureComponent {
         {...rest}
       >
         {renderButtonIcon({ icon, iconPosition })}
-        <span className="button__content">
-          {children || content}
-        </span>
+        {(content || children) && <span className="button__content">{children || content}</span>}
       </button>
     );
   }


### PR DESCRIPTION
Small patch that doesnt render the button content span if there is no content. Allows icon only buttons.