### PR TITLE
make date picker an overlay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codaco/ui",
-  "version": "5.7.5",
+  "version": "5.7.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@codaco/ui",
-      "version": "5.7.5",
+      "version": "5.7.8",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@material-ui/core": "^4.11.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/ui",
-  "version": "5.7.7",
+  "version": "5.7.8",
   "description": "Styles and React components for the Network Canvas project",
   "main": "lib/components/index.js",
   "license": "GPL-3.0-or-later",

--- a/src/components/Fields/DatePicker/DatePicker.js
+++ b/src/components/Fields/DatePicker/DatePicker.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { motion, AnimateSharedLayout, AnimatePresence } from 'framer-motion';
@@ -21,6 +21,8 @@ const DatePickerInput = ({
   parentRef,
   placeholder,
 }) => {
+  const ref = useRef();
+
   const [panelsOpen, setPanelsOpen] = useState(false);
 
   const handleChange = useCallback((newValue) => {
@@ -28,7 +30,28 @@ const DatePickerInput = ({
     if (newValue !== value) { onChangeInput(newValue); }
   }, [value, setPanelsOpen, onChangeInput]);
 
+  const handleClickOutside = e => {
+    if (ref.current.contains(e.target)) {
+      // inside click
+      return;
+    }
+    // outside click
+    setPanelsOpen(false);
+  };
+
   useScrollTo(parentRef, (open) => open, [panelsOpen, parentRef]);
+
+  useEffect(() => {
+    if (panelsOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    } else {
+      document.removeEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [panelsOpen]);
 
   // treat empty string as no value (for Redux Forms)
   const initialDate = isEmpty(value) ? null : value;
@@ -93,7 +116,7 @@ const DatePickerInput = ({
                   isActive={panelsOpen}
                   placeholder={placeholder}
                 />
-                <motion.div layout>
+                <motion.div ref={ref} layout className="date-picker__container">
                   <AnimatePresence>
                     { panelsOpen
                       && (

--- a/src/components/Fields/DatePicker/DatePicker.js
+++ b/src/components/Fields/DatePicker/DatePicker.js
@@ -1,4 +1,6 @@
-import React, { useState, useCallback, useEffect, useRef } from 'react';
+import React, {
+  useState, useCallback, useEffect, useRef,
+} from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { motion, AnimateSharedLayout, AnimatePresence } from 'framer-motion';
@@ -30,7 +32,7 @@ const DatePickerInput = ({
     if (newValue !== value) { onChangeInput(newValue); }
   }, [value, setPanelsOpen, onChangeInput]);
 
-  const handleClickOutside = e => {
+  const handleClickOutside = (e) => {
     if (ref.current.contains(e.target)) {
       // inside click
       return;
@@ -43,13 +45,13 @@ const DatePickerInput = ({
 
   useEffect(() => {
     if (panelsOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
+      document.addEventListener('mousedown', handleClickOutside);
     } else {
-      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener('mousedown', handleClickOutside);
     }
 
     return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [panelsOpen]);
 

--- a/src/styles/components/form/fields/_date-picker.scss
+++ b/src/styles/components/form/fields/_date-picker.scss
@@ -40,7 +40,7 @@ $darken: rgba(0, 0, 0, 0.2);
   --lighten: $lighten;
   --darken: $darken;
   max-width: 100%;
-  overflow: hidden;
+  position: relative;
 
   &__placeholder {
     color: var(--input-placeholder);
@@ -104,9 +104,19 @@ $darken: rgba(0, 0, 0, 0.2);
     }
   }
 
+  &__container {
+    position: absolute;
+    z-index: var(--z-global-ui);
+    width: 100%;
+    max-width: 30rem;
+    box-shadow: 0 2rem 3rem 0 var(--modal-window-box-shadow);
+    margin-bottom: 3rem;
+  }
+
   &__panels {
-    background-color: var(--background);
+    background-color: var(--color-rich-black);
     height: $height;
+    overflow: hidden;
   }
 
   &__panels-container {


### PR DESCRIPTION
Makes date picker an overlay. Clicking outside will close the overlay. Background color for the date-picker in interviewer was transparent, so this changes it to an opaque color so that elements underneath don't show through.

![image](https://user-images.githubusercontent.com/16093053/164365581-d7e0cae6-3837-4f7a-825c-f5bf71665be9.png)


![image](https://user-images.githubusercontent.com/16093053/164365187-9fdbba58-73ee-481c-9073-128328ba9f9d.png)
