### PR TITLE
Add React.memo to Markdown and MarkdownLabel

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -16985,6 +16985,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -17247,6 +17248,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
       "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -19464,6 +19466,7 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
       "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -24475,8 +24478,7 @@
     "@material-ui/types": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
-      "requires": {}
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
     },
     "@material-ui/utils": {
       "version": "4.11.2",
@@ -24609,8 +24611,7 @@
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
       "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@mdx-js/util": {
       "version": "1.6.22",
@@ -24723,8 +24724,7 @@
     "@productboard/slate-edit-list": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@productboard/slate-edit-list/-/slate-edit-list-0.21.5.tgz",
-      "integrity": "sha512-FABqyZPHA+/tzxSBgFnbINvT5XOeQI1toc15oMLWTOHuuqcJjAE7RaGdBZu/0kJAiKm52XTmKxYXkzbzRmRUUw==",
-      "requires": {}
+      "integrity": "sha512-FABqyZPHA+/tzxSBgFnbINvT5XOeQI1toc15oMLWTOHuuqcJjAE7RaGdBZu/0kJAiKm52XTmKxYXkzbzRmRUUw=="
     },
     "@reach/router": {
       "version": "1.3.4",
@@ -24897,8 +24897,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-2.0.0.tgz",
       "integrity": "sha512-ZhdT++cX+L9LwjhGYggvYUUVQH/MGn2rwbrAwCMzA/f2QTFvkjxzX8nDgMxIhaLCDC+gHIxfJG2wrWN0jkBr3g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@storybook/addon-toolbars": {
       "version": "6.3.3",
@@ -26535,8 +26534,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -26601,15 +26599,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "amdefine": {
       "version": "1.0.1",
@@ -27342,8 +27338,7 @@
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.7.tgz",
       "integrity": "sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.2.2",
@@ -33719,8 +33714,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.3.tgz",
       "integrity": "sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.5",
@@ -35904,6 +35898,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -35914,8 +35909,7 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.2.3.tgz",
       "integrity": "sha512-lAge4syxosZg9SX8fJiwOLd9ZJSW3poPBtypnz1aMiFoHsRnK5G3+INGGx9DGtsrso4h5uFYbiFpjAfWyK3Kag==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-compound-slider": {
       "version": "2.5.0",
@@ -36102,13 +36096,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.0.0.tgz",
       "integrity": "sha512-lPf+KJKAo6a9klKyK4y8WwgaX+6t5/HkVjHOpJDMbmaXfXcV7zP0QgWtnEOc3ccEUXKvlHMGUMIS9f6Zgo1BSw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-dom": {
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
       "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -36240,8 +36234,7 @@
     "react-resize-aware": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/react-resize-aware/-/react-resize-aware-3.1.0.tgz",
-      "integrity": "sha512-bIhHlxVTX7xKUz14ksXMEHjzCZPTpQZKZISY3nbTD273pDKPABGFNFBP6Tr42KECxzC5YQiKpMchjTVJCqaxpA==",
-      "requires": {}
+      "integrity": "sha512-bIhHlxVTX7xKUz14ksXMEHjzCZPTpQZKZISY3nbTD273pDKPABGFNFBP6Tr42KECxzC5YQiKpMchjTVJCqaxpA=="
     },
     "react-sizeme": {
       "version": "3.0.1",
@@ -37525,8 +37518,7 @@
           "version": "1.5.1",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
           "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -37862,6 +37854,7 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
       "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -39667,8 +39660,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
       "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "use-latest": {
       "version": "1.2.0",
@@ -40202,8 +40194,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz",
       "integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "webpack-hot-middleware": {
       "version": "2.25.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codaco/ui",
-  "version": "5.7.8",
+  "version": "5.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@codaco/ui",
-      "version": "5.7.8",
+      "version": "5.8.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@material-ui/core": "^4.11.3",
@@ -7059,14 +7059,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001299",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz",
-      "integrity": "sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==",
+      "version": "1.0.30001375",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001375.tgz",
+      "integrity": "sha512-kWIMkNzLYxSvnjy0hL8w1NOaWNr2rn39RTAVyIwcw8juu60bZDWiF1/loOYANzjtJmy6qPgNmn38ro5Pygagdw==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/capture-exit": {
       "version": "2.0.0",
@@ -27994,9 +28000,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001299",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz",
-      "integrity": "sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==",
+      "version": "1.0.30001375",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001375.tgz",
+      "integrity": "sha512-kWIMkNzLYxSvnjy0hL8w1NOaWNr2rn39RTAVyIwcw8juu60bZDWiF1/loOYANzjtJmy6qPgNmn38ro5Pygagdw==",
       "dev": true
     },
     "capture-exit": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codaco/ui",
-  "version": "5.7.8",
+  "version": "5.8.0",
   "description": "Styles and React components for the Network Canvas project",
   "main": "lib/components/index.js",
   "license": "GPL-3.0-or-later",

--- a/src/components/Boolean/BooleanOption.js
+++ b/src/components/Boolean/BooleanOption.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import useResizeAware from 'react-resize-aware';
@@ -60,4 +60,4 @@ BooleanOption.defaultProps = {
   negative: false,
 };
 
-export default BooleanOption;
+export default memo(BooleanOption);

--- a/src/components/Fields/Checkbox.js
+++ b/src/components/Fields/Checkbox.js
@@ -43,7 +43,7 @@ const Checkbox = (props) => {
       {label && <MarkdownLabel inline label={label} className="form-field-inline-label" />}
     </label>
   );
-}
+};
 
 Checkbox.propTypes = {
   label: PropTypes.node,

--- a/src/components/Fields/Checkbox.js
+++ b/src/components/Fields/Checkbox.js
@@ -1,54 +1,48 @@
-import React, { PureComponent } from 'react';
+import React, { memo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import uuid from 'uuid';
 import MarkdownLabel from './MarkdownLabel';
 
-class Checkbox extends PureComponent {
-  constructor(props) {
-    super(props);
+const Checkbox = (props) => {
+  const {
+    label,
+    className,
+    input,
+    disabled,
+    fieldLabel,
+    ...rest
+  } = props;
 
-    this.id = uuid();
-  }
+  const id = useRef(uuid());
 
-  render() {
-    const {
-      label,
-      className,
-      input,
-      disabled,
-      fieldLabel,
-      ...rest
-    } = this.props;
+  const componentClasses = cx(
+    'form-field-checkbox',
+    className,
+    {
+      'form-field-checkbox--disabled': disabled,
+    },
+  );
 
-    const componentClasses = cx(
-      'form-field-checkbox',
-      className,
-      {
-        'form-field-checkbox--disabled': disabled,
-      },
-    );
-
-    return (
-      <label className={componentClasses} htmlFor={this.id}>
-        <input
-          className="form-field-checkbox__input"
-          id={this.id}
-          // input.checked is only provided by redux form if type="checkbox" or type="radio" is
-          // provided to <Field />, so for the case that it isn't we can rely on the more reliable
-          // input.value
-          checked={!!input.value}
-          // eslint-disable-next-line react/jsx-props-no-spreading
-          {...input}
-          // eslint-disable-next-line react/jsx-props-no-spreading
-          {...rest}
-          type="checkbox"
-        />
-        <div className="form-field-checkbox__checkbox" />
-        {label && <MarkdownLabel inline label={label} className="form-field-inline-label" />}
-      </label>
-    );
-  }
+  return (
+    <label className={componentClasses} htmlFor={id.current}>
+      <input
+        className="form-field-checkbox__input"
+        id={id.current}
+        // input.checked is only provided by redux form if type="checkbox" or type="radio" is
+        // provided to <Field />, so for the case that it isn't we can rely on the more reliable
+        // input.value
+        checked={!!input.value}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...input}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...rest}
+        type="checkbox"
+      />
+      <div className="form-field-checkbox__checkbox" />
+      {label && <MarkdownLabel inline label={label} className="form-field-inline-label" />}
+    </label>
+  );
 }
 
 Checkbox.propTypes = {
@@ -66,4 +60,11 @@ Checkbox.defaultProps = {
   disabled: false,
 };
 
-export default Checkbox;
+const areEqual = (prevProps, nextProps) => {
+  const { input: { value: prevValue }, ...prevRest } = prevProps;
+  const { input: { value: nextValue }, ...nextRest } = nextProps;
+
+  return prevValue === nextValue && prevRest === nextRest;
+};
+
+export default memo(Checkbox, areEqual);

--- a/src/components/Fields/Markdown.js
+++ b/src/components/Fields/Markdown.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo, memo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import rehypeRaw from 'rehype-raw';
 import rehypeSanitize from 'rehype-sanitize';
@@ -35,10 +35,18 @@ const Markdown = ({
   allowedElements = ALLOWED_MARKDOWN_TAGS,
   markdownRenderers,
 }) => {
-  const combinedRenderers = {
+  const combinedRenderers = useMemo(() => ({
     ...defaultMarkdownRenderers,
     ...markdownRenderers,
-  };
+  }), [markdownRenderers]);
+
+  const rawText = useMemo(() => {
+    if (!label) {
+      return null;
+    }
+
+    return escapeAngleBracket(label);
+  }, [label]);
 
   return (
     <ReactMarkdown
@@ -48,7 +56,7 @@ const Markdown = ({
       rehypePlugins={[rehypeRaw, rehypeSanitize]}
       unwrapDisallowed
     >
-      {escapeAngleBracket(label)}
+      {rawText}
     </ReactMarkdown>
   );
 };
@@ -66,4 +74,4 @@ Markdown.defaultProps = {
   markdownRenderers: {},
 };
 
-export default Markdown;
+export default memo(Markdown);

--- a/src/components/Fields/MarkdownLabel.js
+++ b/src/components/Fields/MarkdownLabel.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 import PropTypes from 'prop-types';
 import { ALLOWED_MARKDOWN_LABEL_TAGS, ALLOWED_MARKDOWN_INLINE_LABEL_TAGS } from '../../utils/config';
 import Markdown from './Markdown';
@@ -22,4 +22,4 @@ MarkdownLabel.defaultProps = {
   inline: false,
 };
 
-export default MarkdownLabel;
+export default memo(MarkdownLabel);

--- a/src/components/Fields/Text.js
+++ b/src/components/Fields/Text.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { memo, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import uuid from 'uuid';
@@ -52,6 +52,7 @@ const TextInput = ({
   );
 
   const anyLabel = fieldLabel || label;
+
   return (
     <div className="form-field-container" hidden={hidden}>
       { anyLabel
@@ -127,4 +128,4 @@ TextInput.defaultProps = {
   type: 'text',
 };
 
-export default TextInput;
+export default memo(TextInput);

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, memo } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import icons from '../utils/getIcon';
@@ -16,7 +16,7 @@ const Icon = (props) => {
     [`icon--${color}`]: !!color,
   }, [className]);
 
-  const IconComponent = icons(name);
+  const IconComponent = useCallback(icons(name), [name]);
 
   if (!IconComponent) {
     console.warn('Invalid icon name:', name); // eslint-disable-line no-console
@@ -47,4 +47,4 @@ Icon.defaultProps = {
   style: {},
 };
 
-export default Icon;
+export default memo(Icon);

--- a/stories/Text.stories.js
+++ b/stories/Text.stories.js
@@ -11,7 +11,7 @@ const adornments = {
 };
 
 export default {
-  title: 'Components/Text',
+  title: 'Fields/Text',
   args: {
     value: undefined,
     error: 'Something was not right about the input',


### PR DESCRIPTION
React markdown is expensive and was being rendered on keypress when
used with fields. This commit memoizes the markdown rendering components
so that they only re-render when the label changes.